### PR TITLE
Look for separators in the context of sentences

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-metricbot",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-metricbot",
   "description": "Hubot script to add Glossary/Definition feature.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": {
     "name": "Dan Miller",
     "email": "superdoubledan@gmail.com",

--- a/src/metric-bot.coffee
+++ b/src/metric-bot.coffee
@@ -12,13 +12,13 @@ module.exports = (robot) ->
       when tempF < 80 then ":sun_behind_cloud:"
       else ":fire:"
 
-  robot.hear /(-?\d+)\s?(F|Fahrenheit)\b/i, (res) ->
-    tempF = res.match[1];
+  robot.hear /(?:^|[\s,.;!?—–()])((minus |-)?\d+)\s?(F|Fahrenheit)([\s,.;!?—–()]|$)/i, (res) ->
+    tempF = res.match[1].replace('minus ', '-');
     tempC = tempFtoC(tempF)
     res.send "If you can't read 'Murican, #{tempF} in Fahrenheit is #{tempC} degrees Celsius #{temperatureEmoji(tempF)}"
 
-  robot.hear /(-?\d+)\s?(C|Celsius)\b/i, (res) ->
-    tempC = res.match[1];
+  robot.hear /(?:^|[\s,.;!?—–()])((minus |-)?\d+)\s?(C|Celsius)([\s,.;!?—–()]|$)/i, (res) ->
+    tempC = res.match[1].replace('minus ', '-');
     tempF = tempCtoF(tempC)
     res.send "If you live in Liberia, Myanmar or other countries that use the imperial " +
         "system, #{tempC} in Celsius is #{tempF} degrees Fahrenheit #{temperatureEmoji(tempF)}"

--- a/test/metric-bot_test.coffee
+++ b/test/metric-bot_test.coffee
@@ -37,13 +37,6 @@ describe 'definitions', ->
   afterEach ->
     robot.shutdown()
 
-  describe 'listeners', ->
-    it 'registered hear american temperature', ->
-      expect(spies.hear).to.have.been.calledWith(/(-?\d+)\s?(F|Fahrenheit)\b/i)
-
-    it 'registered hear canadian temperature', ->
-      expect(spies.hear).to.have.been.calledWith(/(-?\d+)\s?(C|Celsius)\b/i)
-
   describe 'test conversions to Canadian', ->
     it 'responds to 39F', (done) ->
       adapter.on 'send', (envelope, strings) ->


### PR DESCRIPTION
**Update**:
I straight-up deleted the two tests that are failing, because they make no assertion about the behavior, but the internal implementation details

I'm making a follow-up PR _adding_ a number of tests, cleaning things up, and refactoring.  I think it's tricky to write this kind of negative test—that hubot _doesn't_ reply—the way they are currently written, so hopefully you agree with that change.

--------

since token is expected to be in some kind of English sentence or phrase

Matches temperature at beginning/end of line, before/after a space (or handful of other punctuation), but not in the middle of other junk which may be considered "word separators" in regex but not in normal sentences.

```javascript
> /(^|[\s,.;!?—–()])(-?\d+)\s?(F|Fahrenheit)([\s,.;!?—–()]|$)/i.test('33F')
true
> /(^|[\s,.;!?—–()])(-?\d+)\s?(F|Fahrenheit)([\s,.;!?—–()]|$)/i.test('it is 33 Fahrenheit')
true
> /(^|[\s,.;!?—–()])(-?\d+)\s?(F|Fahrenheit)([\s,.;!?—–()]|$)/i.test('(33 F is fine.)')
true
> /(^|[\s,.;!?—–()])(-?\d+)\s?(F|Fahrenheit)([\s,.;!?—–()]|$)/i.test('%33F+ is not a phrase')
false
> /(^|[\s,.;!?—–()])(-?\d+)\s?(F|Fahrenheit)([\s,.;!?—–()]|$)/i.test('endashes are all like -33F–33F!')
true
```