### PR TITLE
Reduce, reuse, and refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-.idea/**
+*.iml
+.idea/
+/node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,45 +1,9 @@
 {
   "name": "hubot-metricbot",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@sinonjs/commons": {
-      "version": "1.7.0",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/@sinonjs/commons/-/commons-1.7.0.tgz",
-      "integrity": "sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==",
-      "dev": true,
-      "requires": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "@sinonjs/formatio": {
-      "version": "3.2.2",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/@sinonjs/formatio/-/formatio-3.2.2.tgz",
-      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^1",
-        "@sinonjs/samsam": "^3.1.0"
-      }
-    },
-    "@sinonjs/samsam": {
-      "version": "3.3.3",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/@sinonjs/samsam/-/samsam-3.3.3.tgz",
-      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^1.3.0",
-        "array-from": "^2.1.1",
-        "lodash": "^4.17.15"
-      }
-    },
-    "@sinonjs/text-encoding": {
-      "version": "0.7.1",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
-      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
-      "dev": true
-    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://repository.sonatype.org/content/groups/npm/accepts/-/accepts-1.3.7.tgz",
@@ -68,6 +32,16 @@
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
+    "anymatch": {
+      "version": "3.1.1",
+      "resolved": "https://repository.sonatype.org/content/groups/npm/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://repository.sonatype.org/content/groups/npm/argparse/-/argparse-1.0.10.tgz",
@@ -83,18 +57,6 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
-    "array-from": {
-      "version": "2.1.1",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/array-from/-/array-from-2.1.1.tgz",
-      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
-      "dev": true
-    },
-    "assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
-    },
     "async": {
       "version": "0.9.2",
       "resolved": "https://repository.sonatype.org/content/groups/npm/async/-/async-0.9.2.tgz",
@@ -105,6 +67,12 @@
       "version": "1.0.0",
       "resolved": "https://repository.sonatype.org/content/groups/npm/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "binary-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://repository.sonatype.org/content/groups/npm/binary-extensions/-/binary-extensions-2.0.0.tgz",
+      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
     },
     "body-parser": {
@@ -162,6 +130,15 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://repository.sonatype.org/content/groups/npm/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://repository.sonatype.org/content/groups/npm/browser-stdout/-/browser-stdout-1.3.1.tgz",
@@ -180,29 +157,6 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
-    "chai": {
-      "version": "4.2.0",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/chai/-/chai-4.2.0.tgz",
-      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
-      "dev": true,
-      "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.1.0",
-        "type-detect": "^4.0.5"
-      }
-    },
-    "chai-files": {
-      "version": "1.4.0",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/chai-files/-/chai-files-1.4.0.tgz",
-      "integrity": "sha1-DiVhD63FUbHq55wvTuefry+EIpY=",
-      "dev": true,
-      "requires": {
-        "assertion-error": "^1.0.1"
-      }
-    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://repository.sonatype.org/content/groups/npm/chalk/-/chalk-1.1.3.tgz",
@@ -216,11 +170,21 @@
         "supports-color": "^2.0.0"
       }
     },
-    "check-error": {
-      "version": "1.0.2",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
-      "dev": true
+    "chokidar": {
+      "version": "3.3.0",
+      "resolved": "https://repository.sonatype.org/content/groups/npm/chokidar/-/chokidar-3.3.0.tgz",
+      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.1",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.2.0"
+      }
     },
     "cline": {
       "version": "0.8.2",
@@ -268,12 +232,9 @@
       }
     },
     "coffeescript": {
-      "version": "1.7.0",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/coffeescript/-/coffeescript-1.7.0.tgz",
-      "integrity": "sha1-n3vfsoXsZXom8ZMBN5/fcCJNtv0=",
-      "requires": {
-        "mkdirp": "~0.3.5"
-      }
+      "version": "2.5.1",
+      "resolved": "https://repository.sonatype.org/content/groups/npm/coffeescript/-/coffeescript-2.5.1.tgz",
+      "integrity": "sha512-J2jRPX0eeFh5VKyVnoLrfVFgLZtnnmp96WQSLAS8OrLm2wtQLcnikYKe1gViJKDH7vucjuhHvBKKBP3rKcD1tQ=="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -350,15 +311,6 @@
       "resolved": "https://repository.sonatype.org/content/groups/npm/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
-    },
-    "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-      "dev": true,
-      "requires": {
-        "type-detect": "^4.0.0"
-      }
     },
     "define-properties": {
       "version": "1.1.3",
@@ -514,6 +466,15 @@
         "pend": "~1.2.0"
       }
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://repository.sonatype.org/content/groups/npm/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://repository.sonatype.org/content/groups/npm/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -565,6 +526,13 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.1.2",
+      "resolved": "https://repository.sonatype.org/content/groups/npm/fsevents/-/fsevents-2.1.2.tgz",
+      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://repository.sonatype.org/content/groups/npm/function-bind/-/function-bind-1.1.1.tgz",
@@ -575,12 +543,6 @@
       "version": "2.0.5",
       "resolved": "https://repository.sonatype.org/content/groups/npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
-    },
-    "get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "glob": {
@@ -595,6 +557,15 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.0",
+      "resolved": "https://repository.sonatype.org/content/groups/npm/glob-parent/-/glob-parent-5.1.0.tgz",
+      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
       }
     },
     "growl": {
@@ -717,6 +688,15 @@
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
       "dev": true
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://repository.sonatype.org/content/groups/npm/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
     "is-buffer": {
       "version": "2.0.4",
       "resolved": "https://repository.sonatype.org/content/groups/npm/is-buffer/-/is-buffer-2.0.4.tgz",
@@ -735,10 +715,31 @@
       "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
       "dev": true
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://repository.sonatype.org/content/groups/npm/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://repository.sonatype.org/content/groups/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://repository.sonatype.org/content/groups/npm/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://repository.sonatype.org/content/groups/npm/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
     "is-regex": {
@@ -759,12 +760,6 @@
         "has-symbols": "^1.0.1"
       }
     },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "dev": true
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://repository.sonatype.org/content/groups/npm/isexe/-/isexe-2.0.0.tgz",
@@ -780,12 +775,6 @@
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
-    },
-    "just-extend": {
-      "version": "4.0.2",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/just-extend/-/just-extend-4.0.2.tgz",
-      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
-      "dev": true
     },
     "locate-path": {
       "version": "3.0.0",
@@ -849,12 +838,6 @@
         }
       }
     },
-    "lolex": {
-      "version": "4.2.0",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/lolex/-/lolex-4.2.0.tgz",
-      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
-      "dev": true
-    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://repository.sonatype.org/content/groups/npm/media-typer/-/media-typer-0.3.0.tgz",
@@ -910,18 +893,23 @@
       "dev": true
     },
     "mkdirp": {
-      "version": "0.3.5",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/mkdirp/-/mkdirp-0.3.5.tgz",
-      "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
+      "version": "0.5.1",
+      "resolved": "https://repository.sonatype.org/content/groups/npm/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "mocha": {
-      "version": "6.2.2",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/mocha/-/mocha-6.2.2.tgz",
-      "integrity": "sha512-FgDS9Re79yU1xz5d+C4rv1G7QagNGHZ+iXF81hO8zY35YZZcLEsJVfFolfsqKFWunATEvNzMK0r/CwWd/szO9A==",
+      "version": "7.0.1",
+      "resolved": "https://repository.sonatype.org/content/groups/npm/mocha/-/mocha-7.0.1.tgz",
+      "integrity": "sha512-9eWmWTdHLXh72rGrdZjNbG3aa1/3NRPpul1z0D979QpEnFdCG0Q5tv834N+94QEN2cysfV72YocQ3fn87s70fg==",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
         "browser-stdout": "1.3.1",
+        "chokidar": "3.3.0",
         "debug": "3.2.6",
         "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
@@ -934,7 +922,7 @@
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "ms": "2.1.1",
-        "node-environment-flags": "1.0.5",
+        "node-environment-flags": "1.0.6",
         "object.assign": "4.1.0",
         "strip-json-comments": "2.0.1",
         "supports-color": "6.0.0",
@@ -952,15 +940,6 @@
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://repository.sonatype.org/content/groups/npm/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
           }
         },
         "ms": {
@@ -1004,48 +983,21 @@
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
       "dev": true
     },
-    "nise": {
-      "version": "1.5.3",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/nise/-/nise-1.5.3.tgz",
-      "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/formatio": "^3.2.1",
-        "@sinonjs/text-encoding": "^0.7.1",
-        "just-extend": "^4.0.2",
-        "lolex": "^5.0.1",
-        "path-to-regexp": "^1.7.0"
-      },
-      "dependencies": {
-        "lolex": {
-          "version": "5.1.2",
-          "resolved": "https://repository.sonatype.org/content/groups/npm/lolex/-/lolex-5.1.2.tgz",
-          "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
-          "dev": true,
-          "requires": {
-            "@sinonjs/commons": "^1.7.0"
-          }
-        },
-        "path-to-regexp": {
-          "version": "1.8.0",
-          "resolved": "https://repository.sonatype.org/content/groups/npm/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-          "dev": true,
-          "requires": {
-            "isarray": "0.0.1"
-          }
-        }
-      }
-    },
     "node-environment-flags": {
-      "version": "1.0.5",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
-      "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+      "version": "1.0.6",
+      "resolved": "https://repository.sonatype.org/content/groups/npm/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
       "dev": true,
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
       }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://repository.sonatype.org/content/groups/npm/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.7.0",
@@ -1153,16 +1105,16 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
-    "pathval": {
-      "version": "1.1.0",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
-      "dev": true
-    },
     "pend": {
       "version": "1.2.0",
       "resolved": "https://repository.sonatype.org/content/groups/npm/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.2.1",
+      "resolved": "https://repository.sonatype.org/content/groups/npm/picomatch/-/picomatch-2.2.1.tgz",
+      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
       "dev": true
     },
     "proxy-addr": {
@@ -1224,6 +1176,15 @@
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         }
+      }
+    },
+    "readdirp": {
+      "version": "3.2.0",
+      "resolved": "https://repository.sonatype.org/content/groups/npm/readdirp/-/readdirp-3.2.0.tgz",
+      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.0.4"
       }
     },
     "require-directory": {
@@ -1315,38 +1276,6 @@
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
       "dev": true
     },
-    "sinon": {
-      "version": "7.5.0",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/sinon/-/sinon-7.5.0.tgz",
-      "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^1.4.0",
-        "@sinonjs/formatio": "^3.2.1",
-        "@sinonjs/samsam": "^3.3.3",
-        "diff": "^3.5.0",
-        "lolex": "^4.2.0",
-        "nise": "^1.5.2",
-        "supports-color": "^5.5.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://repository.sonatype.org/content/groups/npm/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
-    "sinon-chai": {
-      "version": "3.4.0",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/sinon-chai/-/sinon-chai-3.4.0.tgz",
-      "integrity": "sha512-BpVxsjEkGi6XPbDXrgWUe7Cb1ZzIfxKUbu/MmH5RoUnS7AXpKo3aIYIyQUg0FMvlUL05aPt7VZuAdaeQhEnWxg==",
-      "dev": true
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://repository.sonatype.org/content/groups/npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -1427,16 +1356,19 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://repository.sonatype.org/content/groups/npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://repository.sonatype.org/content/groups/npm/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-      "dev": true
-    },
-    "type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://repository.sonatype.org/content/groups/npm/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "type-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-metricbot",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-metricbot",
   "description": "Hubot script to add Glossary/Definition feature.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": {
     "name": "Dan Miller",
     "email": "superdoubledan@gmail.com",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-metricbot",
   "description": "Hubot script to add Glossary/Definition feature.",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "author": {
     "name": "Dan Miller",
     "email": "superdoubledan@gmail.com",
@@ -19,17 +19,13 @@
     "private": true
   },
   "dependencies": {
-    "coffeescript": "~1.7"
+    "coffeescript": "^2.5.1"
   },
   "peerDependencies": {},
   "devDependencies": {
-    "chai": "*",
-    "chai-files": "^1.4.0",
     "hubot": "^3.0.1",
     "hubot-mock-adapter": "^1.0.0",
-    "mocha": "^6.2.1",
-    "sinon": "^7.5.0",
-    "sinon-chai": "*"
+    "mocha": "^7.0.1"
   },
   "main": "index.coffee",
   "scripts": {

--- a/src/metric-bot.coffee
+++ b/src/metric-bot.coffee
@@ -12,13 +12,13 @@ module.exports = (robot) ->
       when tempF < 80 then ":sun_behind_cloud:"
       else ":fire:"
 
-  robot.hear /(-?\d+)\s?(F|Fahrenheit)\b/i, (res) ->
-    tempF = res.match[1];
+  robot.hear /(?:^|[\s,.;!?—–()])((minus |-)?\d+)\s?(F|Fahrenheit)([\s,.;!?—–()]|$)/i, (res) ->
+    tempF = res.match[1].replace('minus ', '-');
     tempC = tempFtoC(tempF)
     res.send "If you can't read 'Murican, #{tempF} in Fahrenheit is #{tempC} degrees Celsius #{temperatureEmoji(tempF)}"
 
-  robot.hear /(-?\d+)\s?(C|Celsius)\b/i, (res) ->
-    tempC = res.match[1];
+  robot.hear /(?:^|[\s,.;!?—–()])((minus |-)?\d+)\s?(C|Celsius)([\s,.;!?—–()]|$)/i, (res) ->
+    tempC = res.match[1].replace('minus ', '-');
     tempF = tempCtoF(tempC)
     res.send "If you live in Liberia, Myanmar or other countries that use the imperial " +
         "system, #{tempC} in Celsius is #{tempF} degrees Fahrenheit #{temperatureEmoji(tempF)}"

--- a/src/metric-bot.coffee
+++ b/src/metric-bot.coffee
@@ -1,24 +1,40 @@
 module.exports = (robot) ->
 
-  tempFtoC = (tempF) ->
-    Math.floor((tempF - 32) * (5 / 9))
+  units = [
+    {
+      symbol: 'F'
+      name: 'Fahrenheit'
+      matchers: [ 'F', 'Fahrenheit', 'Farenheit' ]
+      condition: "If you can't read 'Murican"
+      to:
+        C: (degrees) -> Math.floor((degrees - 32) * (5 / 9))
+      getEmoji: (degrees) ->
+        switch
+          when degrees <= 32 then ":snowflake:"
+          when degrees < 80 then ":sun_behind_cloud:"
+          else ":fire:"
+    },
+    {
+      symbol: 'C'
+      name: 'Celsius'
+      matchers: [ 'C', 'Celsius', 'Centigrade' ]
+      condition: 'If you live in Liberia, Myanmar or other countries that use the imperial system'
+      to:
+        F: (degrees) -> Math.floor((9 * degrees / 5) + 32)
+      getEmoji: (degrees) ->
+        switch
+          when degrees <= 0 then ":snowflake:"
+          when degrees < 26 then ":sun_behind_cloud:"
+          else ":fire:"
+    }
+  ]
 
-  tempCtoF = (tempC) ->
-    Math.floor((9 * tempC / 5) + 32)
+  unitTokens = units.flatMap( (unit) -> unit.matchers).join('|')
+  matcher = new RegExp("(?:^|[\\s,.;!?—–()])((?:minus |-)?\\d+)°?\\s?(#{unitTokens})([\\s,.;!?—–()]|$)")
 
-  temperatureEmoji = (tempF) ->
-    switch
-      when tempF <= 32 then ":snowflake:"
-      when tempF < 80 then ":sun_behind_cloud:"
-      else ":fire:"
-
-  robot.hear /(?:^|[\s,.;!?—–()])((minus |-)?\d+)\s?(F|Fahrenheit)([\s,.;!?—–()]|$)/i, (res) ->
-    tempF = res.match[1].replace('minus ', '-');
-    tempC = tempFtoC(tempF)
-    res.send "If you can't read 'Murican, #{tempF} in Fahrenheit is #{tempC} degrees Celsius #{temperatureEmoji(tempF)}"
-
-  robot.hear /(?:^|[\s,.;!?—–()])((minus |-)?\d+)\s?(C|Celsius)([\s,.;!?—–()]|$)/i, (res) ->
-    tempC = res.match[1].replace('minus ', '-');
-    tempF = tempCtoF(tempC)
-    res.send "If you live in Liberia, Myanmar or other countries that use the imperial " +
-        "system, #{tempC} in Celsius is #{tempF} degrees Fahrenheit #{temperatureEmoji(tempF)}"
+  robot.hear matcher, (res) ->
+    fromUnit = units.find (unit) -> unit.matchers.includes(res.match[2])
+    toUnit = units.find (unit) -> unit != fromUnit # this is silly
+    fromDegrees = +res.match[1].replace(/minus /i, '-')
+    toDegrees = fromUnit.to[toUnit.symbol](fromDegrees)
+    res.send "#{fromUnit.condition}, #{fromDegrees} in #{fromUnit.name} is #{toDegrees} degrees #{toUnit.name} #{toUnit.getEmoji(toDegrees)}"

--- a/test/metric-bot_test.coffee
+++ b/test/metric-bot_test.coffee
@@ -1,68 +1,63 @@
-chai = require 'chai'
-sinon = require 'sinon'
-chai.use require 'sinon-chai'
-
-expect = chai.expect
+assert = require 'assert'
 
 Robot       = require 'hubot/src/robot'
 TextMessage = require('hubot/src/message').TextMessage
 
 describe 'definitions', ->
   robot = {}
-  user = {}
-  adapter = {}
-  spies = {}
 
-  beforeEach (done) ->
+  beforeEach ->
     # Create new robot, with http, using mock adapter
     robot = new Robot null, 'mock-adapter', true
-
-    robot.adapter.on 'connected', =>
-      spies.hear = sinon.spy(robot, 'hear')
-      spies.respond = sinon.spy(robot, 'respond')
-
+    robot.adapter.on 'connected', ->
       require('../src/metric-bot')(robot)
-
-      user = robot.brain.userForId '1', {
-        name: 'user'
-        room: '#test'
-      }
-
-      adapter = robot.adapter
-
     robot.run()
-
-    done()
 
   afterEach ->
     robot.shutdown()
 
+  # (async) Resolves to hubots first reply to a given message, or rejects if no reply is made within the timeout
+  reply = (message) ->
+    return Promise.race [
+      new Promise((resolve, reject) -> setTimeout((() -> reject('No reply')), 500)),
+      new Promise((resolve, reject) ->
+        robot.adapter.on 'send', (envelope, strings) -> resolve(strings[0])
+        robot.adapter.receive(new TextMessage {}, message)
+      )
+    ]
+
   describe 'test conversions to Canadian', ->
-    it 'responds to 39F', (done) ->
-      adapter.on 'send', (envelope, strings) ->
-        expect(strings[0]).to.match /39 in Fahrenheit is 3 degrees Celsius/
-        done()
-
-      adapter.receive(new TextMessage user, 'it is 39F today')
-
-    it 'responds to 39 Fahrenheit', (done) ->
-      adapter.on 'send', (envelope, strings) ->
-        expect(strings[0]).to.match /39 in Fahrenheit is 3 degrees Celsius/
-        done()
-
-      adapter.receive(new TextMessage user, 'it is 39 Fahrenheit today')
+    it 'responds to 39F', ->
+      assert.match await reply('it is 39F today'), /39 in Fahrenheit is 3 degrees Celsius/
+    it 'responds to 39 Fahrenheit', ->
+      assert.match await reply('it is 39 Fahrenheit today'), /39 in Fahrenheit is 3 degrees Celsius/
 
   describe 'test conversions to American', ->
-    it 'responds to 12C', (done) ->
-      adapter.on 'send', (envelope, strings) ->
-        expect(strings[0]).to.match /12 in Celsius is 53 degrees Fahrenheit/
-        done()
+    it 'responds to 12C', ->
+      assert.match await reply('hubot: it feels like 12C today'), /12 in Celsius is 53 degrees Fahrenheit/
+    it 'responds to 12 Celsius', ->
+      assert.match await reply('hubot: it feels like 12 Celsius today'), /12 in Celsius is 53 degrees Fahrenheit/
 
-      adapter.receive(new TextMessage user, 'hubot: it feels like 12C today')
+  describe 'test conversions to American', ->
+    it 'responds to 12C', ->
+      assert.match await reply('hubot: it feels like 12C today'), /12 in Celsius is 53 degrees Fahrenheit/
+    it 'responds to 12 Celsius', ->
+      assert.match await reply('hubot: it feels like 12 Celsius today'), /12 in Celsius is 53 degrees Fahrenheit/
 
-    it 'responds to 12 Celsius', (done) ->
-      adapter.on 'send', (envelope, strings) ->
-        expect(strings[0]).to.match /12 in Celsius is 53 degrees Fahrenheit/
-        done()
+  describe 'test negation', ->
+    it 'minus', ->
+      assert.match await reply('hubot: it feels like -12C today'), /-12 in Celsius is 10 degrees Fahrenheit/
+    it 'minus sign', ->
+      assert.match await reply('hubot: it feels like minus 12 Celsius today'), /-12 in Celsius is 10 degrees Fahrenheit/
 
-      adapter.receive(new TextMessage user, 'hubot: it feels like 12 Celsius today')
+  describe 'test degree sign', ->
+    it 'there can be a degree sign immediately after the number of degrees', ->
+      assert.match await reply('hubot: it feels like -12°C today'), /-12 in Celsius is 10 degrees Fahrenheit/
+
+  describe 'test spam prevention', ->
+    it 'ignores URLs', ->
+      assert.rejects reply('hubot: https://docs.sonatype.com/display/LRN/Improvement+Day+-+Session+72+-+February+6%2C+2020')
+    it 'ignores commit hashes', ->
+      assert.rejects reply('hubot: 231596cbb5f0321ab77e6f22a558aa8f988fe43d')
+    it 'ignores the World Wide Web Consortium', ->
+      assert.rejects reply('hubot: I <3 the W3C')

--- a/test/metric-bot_test.coffee
+++ b/test/metric-bot_test.coffee
@@ -37,13 +37,6 @@ describe 'definitions', ->
   afterEach ->
     robot.shutdown()
 
-  describe 'listeners', ->
-    it 'registered hear american temperature', ->
-      expect(spies.hear).to.have.been.calledWith(/(-?\d+)\s?(F|Fahrenheit)\b/i)
-
-    it 'registered hear canadian temperature', ->
-      expect(spies.hear).to.have.been.calledWith(/(-?\d+)\s?(C|Celsius)\b/i)
-
   describe 'test conversions to Canadian', ->
     it 'responds to 39F', (done) ->
       adapter.on 'send', (envelope, strings) ->


### PR DESCRIPTION
This includes #2 

- Simplified tests, extracting repeated code, replacing callback style
- Removed unneeded dependencies
- Add tests for spam prevention
- Refactored to generalize conversion logic (anticipating other units)
- Updated some dependencies

I refactored the implementation to make it generic around a list of convertible units.  On the downside, the expression looks a little bit gnarlier, but I am hoping to build on this to convert other types of units, like distance, and probably expose a more pointed "convert 99F to C" style handler as well.

With the tests, I think the built-in assert API is the bee's knees and—once refactored—is much simpler to read and write without using the other libraries.  What do you think?