### PR TITLE
Mostly bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.iml
 .idea/
+/.hubot_history
 /node_modules/

--- a/README.md
+++ b/README.md
@@ -1,10 +1,35 @@
 # Metric Bot
 
-A Hubot converter between imperial and metric units 
-
+A Hubot converter between imperial and metric units
 
 ![GitHub Actions status | Gavitron/hubot-terminator](https://github.com/Gavitron/hubot-terminator/workflows/Node%20CI/badge.svg)
 
 ## Features
 
-* Converts between Celsius and Fahrenheit measurements
+* Converts temperatures between Celsius, Fahrenheit, and kelvin measurements
+* Converts distances between miles and kilometers
+
+## Requirements
+
+* [Node.js](https://nodejs.org/en/), Current or LTS
+
+## Setup
+
+### Install dependencies
+```shell script
+npm install
+```
+
+## Running
+
+### Start an interactive shell
+```shell script
+npm start
+```
+
+## Testing
+
+### Run unit tests
+```shell script
+npm test
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-metricbot",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-metricbot",
-  "version": "1.4.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-metricbot",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-metricbot",
   "description": "Hubot script to add Glossary/Definition feature.",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": {
     "name": "Dan Miller",
     "email": "superdoubledan@gmail.com",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-metricbot",
   "description": "Hubot script to add Glossary/Definition feature.",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "author": {
     "name": "Dan Miller",
     "email": "superdoubledan@gmail.com",
@@ -29,6 +29,7 @@
   },
   "main": "index.coffee",
   "scripts": {
+    "start": "hubot -r .",
     "test": "script/test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-metricbot",
   "description": "Hubot script to add Glossary/Definition feature.",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "author": {
     "name": "Dan Miller",
     "email": "superdoubledan@gmail.com",

--- a/src/metric-bot.coffee
+++ b/src/metric-bot.coffee
@@ -5,7 +5,7 @@ module.exports = (robot) ->
       symbol: 'F'
       name: 'Fahrenheit'
       matchers: [ 'F', 'Fahrenheit', 'Farenheit' ]
-      reason: "If you can't read 'Murican"
+      reason: 'If you live in Liberia, Myanmar or other countries that use the imperial system'
       to:
         C: (degrees) -> Math.floor((degrees - 32) * (5 / 9))
         K: (degrees) -> Math.floor((degrees + 459.67) * (5 / 9))
@@ -19,7 +19,7 @@ module.exports = (robot) ->
       symbol: 'C'
       name: 'Celsius'
       matchers: [ 'C', 'Celsius', 'Centigrade' ]
-      reason: 'If you live in Liberia, Myanmar or other countries that use the imperial system'
+      reason: "If you can't read 'Murican"
       to:
         F: (degrees) -> Math.floor((9 * degrees / 5) + 32)
         K: (degrees) -> Math.floor(degrees + 273.15)
@@ -35,8 +35,8 @@ module.exports = (robot) ->
       matchers: [ 'K', 'Kelvin', 'kelvin' ]
       reason: 'If you\'re a quantum mechanic'
       to:
-        C: (degrees) -> Math.floor(degrees - 273.15)
-        F: (degrees) -> Math.floor(degrees * (9 / 5) + 459.67)
+        C: (degrees) -> degrees - 273.15
+        F: (degrees) -> degrees * (9 / 5) - 459.67
       getEmoji: (degrees) -> ""
     },
     {
@@ -60,10 +60,11 @@ module.exports = (robot) ->
   ]
 
   negationTokens = 'negative |minus |-'
+  number = "(?:#{negationTokens})?\\d+(?:\\.\\d+)?"
   unitTokens = units.flatMap( (unit) -> unit.matchers).join('|')
 
   # respond when someone asks to convert between two units specifically
-  robot.hear new RegExp("(?:convert)?\\s*(?:from)?\\s*((?:#{negationTokens})?\\d+)°?\\s?(#{unitTokens}) to (#{unitTokens})\\b", 'i'), (res) ->
+  robot.hear new RegExp("(?:convert)?\\s*(?:from)?\\s*(#{number})°?\\s?(#{unitTokens}) to (#{unitTokens})\\b", 'i'), (res) ->
     fromUnit = units.find (unit) -> unit.matchers.includes(res.match[2])
     toUnit = units.find (unit) -> unit.matchers.includes(res.match[3])
     fromDegrees = +res.match[1].replace(new RegExp(negationTokens, 'i'), '-')
@@ -73,9 +74,9 @@ module.exports = (robot) ->
     res.send "#{fromDegrees} #{fromUnit.name} is #{toDegrees} #{toUnit.name}"
 
   # fuzzier matching when someone just mentions an amount
-  robot.hear new RegExp("(?:^|[\\s,.;!?—–()])((?:#{negationTokens})?\\d+)°?\\s?(#{unitTokens})([\\s,.;!?—–()]|$)", 'i'), (res) ->
+  robot.hear new RegExp("(?:^|[\\s,.;!?—–()])(#{number})°?\\s?(#{unitTokens})([\\s,.;!?—–()]|$)", 'i'), (res) ->
     fromUnit = units.find (unit) -> unit.matchers.includes(res.match[2])
     toUnit = units.find (unit) -> unit.to[fromUnit.symbol] # a conversion function exists
     fromDegrees = +res.match[1].replace(new RegExp(negationTokens, 'i'), '-')
     toDegrees = fromUnit.to[toUnit.symbol](fromDegrees)
-    res.send "#{fromUnit.reason}, #{fromDegrees} #{fromUnit.name} is #{toDegrees} #{toUnit.name} #{toUnit.getEmoji(toDegrees)}"
+    res.send "#{toUnit.reason}, #{fromDegrees} #{fromUnit.name} is #{toDegrees} #{toUnit.name} #{toUnit.getEmoji(toDegrees)}"

--- a/src/metric-bot.coffee
+++ b/src/metric-bot.coffee
@@ -65,8 +65,8 @@ module.exports = (robot) ->
 
   # respond when someone asks to convert between two units specifically
   robot.hear new RegExp("(?:convert)?\\s*(?:from)?\\s*(#{number})°?\\s?(#{unitTokens}) to (#{unitTokens})\\b", 'i'), (res) ->
-    fromUnit = units.find (unit) -> unit.matchers.includes(res.match[2])
-    toUnit = units.find (unit) -> unit.matchers.includes(res.match[3])
+    fromUnit = units.find (unit) -> unit.matchers.find (matcher) -> matcher.toLowerCase() == res.match[2].toLowerCase()
+    toUnit = units.find (unit) -> unit.matchers.find (matcher) -> matcher.toLowerCase() == res.match[3].toLowerCase()
     fromDegrees = +res.match[1].replace(new RegExp(negationTokens, 'i'), '-')
     if (fromUnit.to[toUnit.symbol] == undefined)
       return res.send "Sorry, I don't know how to convert #{fromUnit.name} to #{toUnit.name}"
@@ -75,7 +75,7 @@ module.exports = (robot) ->
 
   # fuzzier matching when someone just mentions an amount
   robot.hear new RegExp("(?:^|[\\s,.;!?—–()])(#{number})°?\\s?(#{unitTokens})([\\s,.;!?—–()]|$)", 'i'), (res) ->
-    fromUnit = units.find (unit) -> unit.matchers.includes(res.match[2])
+    fromUnit = units.find (unit) -> unit.matchers.find (matcher) -> matcher.toLowerCase() == res.match[2].toLowerCase()
     toUnit = units.find (unit) -> unit.to[fromUnit.symbol] # a conversion function exists
     fromDegrees = +res.match[1].replace(new RegExp(negationTokens, 'i'), '-')
     toDegrees = fromUnit.to[toUnit.symbol](fromDegrees)

--- a/test/metric-bot_test.coffee
+++ b/test/metric-bot_test.coffee
@@ -75,3 +75,11 @@ describe 'definitions', ->
       assert.rejects reply('hubot: 231596cbb5f0321ab77e6f22a558aa8f988fe43d')
     it 'ignores the World Wide Web Consortium', ->
       assert.rejects reply('hubot: I <3 the W3C')
+
+  describe 'test decimal point', ->
+    it 'there can be a decimal point in the number', ->
+      assert.match await reply('hubot: -459.67°F to K'), /-459.67 Fahrenheit is 0 kelvin/
+
+  describe 'test kelvin', ->
+    it 'it converts Kelvin correctly', ->
+      assert.match await reply('hubot: 0 kelvin to F'), /0 kelvin is -459.67 Fahrenheit/

--- a/test/metric-bot_test.coffee
+++ b/test/metric-bot_test.coffee
@@ -75,6 +75,8 @@ describe 'definitions', ->
       assert.rejects reply('hubot: 231596cbb5f0321ab77e6f22a558aa8f988fe43d')
     it 'ignores the World Wide Web Consortium', ->
       assert.rejects reply('hubot: I <3 the W3C')
+    it 'ignores mentions of kelvin, since it is not common in conversation', ->
+      assert.rejects reply('hubot: the Baron Kelvin ran a 5k')
 
   describe 'test decimal point', ->
     it 'there can be a decimal point in the number', ->


### PR DESCRIPTION
My last change reduced spam and added support for the standard metric unit of temperature, but left a few bugs that I have fixed here:

* Cover all the bases in the README, and fire up a REPL when you run `npm start`
* When the message is explicit like "convert 100 Fahrenheit to kelvin", only handle it that way and don't match again on the fuzzier "mention" regex and give two responses
* Convert from kelvin correctly
* _Don't_ convert from kelvin on mention, since that's probably spam
* Get the "reasons" straight (convert _to_ Fahrenheit in case you use the imperial system)
* handle decimals, and don't round when converting from kelvin (because you're obviously being pedantic)